### PR TITLE
Enhancement travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: php
+php:
+  - '7.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.0
+  - 7.2.1
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,13 @@
 language: php
+
 php:
-  - '7.0'
+  - 7.0
+
+before_script:
+  - cp .env.travis .env
+  - composer self-update
+  - composer install --no-interaction
+
+script:
+  - php artisan key:generate
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
 
 before_script:
-  - cp .env.travis .env
   - composer self-update
   - composer install --no-interaction
 


### PR DESCRIPTION
Travis CI is set up and passing on this branch now for PHPUnit (the test framework laravel comes with). It is not currently configured to test the front end (ie. javascript) due to time and complexity constraints. I will be testing out setting up javascript testing in the future. 

Incidentally laravel already includes empty test functions that are currently passing that we need for sprint 3.

This resolves #35 