### PR TITLE
Fixed an improperly named value

### DIFF
--- a/app/Http/Controllers/QuestionsRetrievalController.php
+++ b/app/Http/Controllers/QuestionsRetrievalController.php
@@ -18,7 +18,7 @@ class QuestionsRetrievalController extends Controller
         foreach($questions as &$question)
         {
             $question->author = DB::table('users')->where('id', '=', $question->author)->value('name');
-            if( !isset($question->user) )
+            if( !isset($question->author) )
             {
                 $question->author = 'Non-Existent User';
             }


### PR DESCRIPTION
The value had previously been named 'user' but was changed to author. There was an unchanged instance